### PR TITLE
Update flavor.toml → Permission colors

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -53,9 +53,9 @@ progress_error  = { fg = "#f7768e", bg = "#414868" }  # Red on Darkened black
 
 # Permissions
 permissions_t = { fg = "#7aa2f7" }  # Blue
-permissions_r = { fg = "#f7768e" }  # Red
+permissions_r = { fg = "##9ece6a" }  # Green
 permissions_w = { fg = "#e0af68" }  # Yellow
-permissions_x = { fg = "#9ece6a" }  # Green
+permissions_x = { fg = "#f7768e" }  # Red
 permissions_s = { fg = "#bb9af7" }  # Magenta
 
 # : }}}


### PR DESCRIPTION
This PR keep the same colors. We just order them by privilege level:

* green: read
* yellow: write
* red: execution

For the extra flags we also keep the same colors
* blue: is_directory
* magenta: execute_with_owner_uid

This tiny change makes it a bit easier to read.