### PR TITLE
tokyo-night.yazi: Add support for Yazi 0.4 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Add the these lines to your `theme.toml` configuration file to use it:
 ```toml
 [flavor]
 use = "tokyo-night"
+# For Yazi 0.4 and above
+dark = "tokyo-night"
 ```
 
 ## 📜 License

--- a/flavor.toml
+++ b/flavor.toml
@@ -1,3 +1,5 @@
+# vim:fileencoding=utf-8:foldmethod=marker
+
 # : Manager {{{
 
 [manager]
@@ -34,17 +36,29 @@ border_style  = { fg = "#414868" }  # Darkened black
 # : }}}
 
 
-# : Status {{{
+# : Mode {{{
+
+[mode]
+
+normal_main = { fg = "#414868", bg = "#7aa2f7", bold = true }  # Darkened black on Blue
+normal_alt  = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
+
+# Select mode
+select_main = { fg = "#414868", bg = "#9ece6a", bold = true }  # Darkened black on Green
+select_alt  = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
+
+# Unset mode
+unset_main = { fg = "#414868", bg = "#bb9af7", bold = true }  # Darkened black on Magenta
+unset_alt  = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
+
+# : }}}
+
+
+# : Status bar {{{
 
 [status]
 separator_open  = ""
 separator_close = ""
-separator_style = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
-
-# Mode
-mode_normal = { fg = "#414868", bg = "#7aa2f7", bold = true }  # Darkened black on Blue
-mode_select = { fg = "#414868", bg = "#9ece6a", bold = true }  # Darkened black on Green
-mode_unset  = { fg = "#414868", bg = "#bb9af7", bold = true }  # Darkened black on Magenta
 
 # Progress
 progress_label  = { fg = "#a9b1d6", bold = true }  # White
@@ -52,21 +66,40 @@ progress_normal = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
 progress_error  = { fg = "#f7768e", bg = "#414868" }  # Red on Darkened black
 
 # Permissions
+perm_sep   = { fg = "#7aa2f7" }  # Blue
+perm_type  = { fg = "#9ece6a" }  # Green
+perm_read  = { fg = "#e0af68" }  # Yellow
+perm_write = { fg = "#f7768e" }  # Red
+perm_exec  = { fg = "#bb9af7" }  # Magenta
+
+# TODO: -- remove these once Yazi 0.4 gets released
+separator_style = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
+mode_normal = { fg = "#414868", bg = "#7aa2f7", bold = true }  # Darkened black on Blue
+mode_select = { fg = "#414868", bg = "#9ece6a", bold = true }  # Darkened black on Green
+mode_unset  = { fg = "#414868", bg = "#bb9af7", bold = true }  # Darkened black on Magenta
 permissions_t = { fg = "#7aa2f7" }  # Blue
 permissions_r = { fg = "#9ece6a" }  # Green
 permissions_w = { fg = "#e0af68" }  # Yellow
 permissions_x = { fg = "#f7768e" }  # Red
 permissions_s = { fg = "#bb9af7" }  # Magenta
+# TODO: remove these once Yazi 0.4 gets released --
 
 # : }}}
 
 
-# : Select {{{
-
-[select]
-border   = { fg = "#7aa2f7" }  # Blue
-active   = { fg = "#bb9af7", bold = true }  # Magenta
+# : Pick {{{
+	
+[pick]
+border = { fg = "#7aa2f7" }  # Blue
+active = { fg = "#bb9af7", bold = true }  # Magenta
 inactive = {}
+
+# TODO: -- remove these once Yazi 0.4 gets released
+[select]
+border = { fg = "#7aa2f7" }  # Blue
+active = { fg = "#bb9af7", bold = true }  # Magenta
+inactive = {}
+# TODO: remove these once Yazi 0.4 gets released --
 
 # : }}}
 
@@ -98,6 +131,8 @@ title   = {}
 hovered = { fg = "#bb9af7", underline = true }  # Magenta
 
 # : }}}
+
+
 # : Which {{{
 
 [which]


### PR DESCRIPTION
This PR adds support for yazi 0.4 and above to the tokyo-night.yazi flavor.

This change is necessary because the original flavor was incompatible with the latest versions of Yazi, which introduced breaking changes. This PR updates the flavor to work seamlessly with Yazi 0.4 and all subsequent versions.