### PR TITLE
Fix statusbar pill color

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -59,7 +59,7 @@ unset_alt  = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
 [status]
 separator_open  = ""
 separator_close = ""
-separator_style = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
+separator_style = { fg = "#414868", bg = "#414868" }  # Blue on Darkened black
 
 
 # Progress
@@ -78,7 +78,7 @@ perm_exec  = { fg = "#bb9af7" }  # Magenta
 # : }}}
 
 # : Pick {{{
-	
+
 [pick]
 border = { fg = "#7aa2f7" }  # Blue
 active = { fg = "#bb9af7", bold = true }  # Magenta


### PR DESCRIPTION
Noticed a style issue with the statusbar. Took reference from fellow flavor [Everforest Medium](https://github.com/Chromium-3-Oxide/everforest-medium.yazi) and fixed it.

Before:
![image](https://github.com/user-attachments/assets/1f231455-ad8e-4334-82ee-3a9dafdaab44)
After:
![image](https://github.com/user-attachments/assets/72f1a71b-8c54-41e8-af18-b07ade4d5a8f)
