### PR TITLE
fix: Label not visible

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -135,7 +135,7 @@ separator_style = { fg = "#626880" }  # Darkened gray
 on      = { fg = "#9ece6a" }  # Green
 run     = { fg = "#bb9af7" }  # Magenta
 hovered = { reversed = true, bold = true }
-footer  = { fg = "#a9b1d6", bg = "#c6d0f5" }  # White on Light gray
+footer  = { fg = "#1a1b26", bg = "#c6d0f5" }  # White on Light gray
 
 # : }}}
 

--- a/flavor.toml
+++ b/flavor.toml
@@ -63,9 +63,9 @@ separator_style = { fg = "#414868", bg = "#414868" }  # Blue on Darkened black
 
 
 # Progress
-progress_label  = { fg = "#a9b1d6", bold = true }  # White
-progress_normal = { fg = "#7aa2f7", bg = "#414868" }  # Blue on Darkened black
-progress_error  = { fg = "#f7768e", bg = "#414868" }  # Red on Darkened black
+progress_label = { fg = "#1a1b26", bold = true }
+progress_normal = { fg = "#7aa2f7", bg = "#292e42" }
+progress_error = { fg = "#f7768e", bg = "#292e42" }
 
 # Permissions
 perm_sep   = { fg = "#7aa2f7" }  # Blue


### PR DESCRIPTION
### progress_label

Before:
![Shot-2025-05-03-211744](https://github.com/user-attachments/assets/51fd0383-2184-4638-a8e9-4ce12cb3a112)

After:
![Shot-2025-05-03-211850](https://github.com/user-attachments/assets/7187a95f-fe6f-4ec8-a170-a7d045d9d6f8)

### help footer label

Before:
![Shot-2025-05-03-233549](https://github.com/user-attachments/assets/3e12218e-395a-46f7-8e24-61db0bea4556)

After:
![Shot-2025-05-03-233626](https://github.com/user-attachments/assets/ecbbb9e2-d57e-4fa3-aff1-f18953df717a)

I don't know if it has something to do with my [yatline](https://github.com/imsi32/yatline.yazi) theme.